### PR TITLE
Modularize Commands More

### DIFF
--- a/cogs/Admin/synch.py
+++ b/cogs/Admin/synch.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands 
 
-class BotAdmin(commands.Cog):
+class Synch(commands.Cog):
     def __init__(self, client):
         self.client = client
         
@@ -15,4 +15,4 @@ class BotAdmin(commands.Cog):
         
 
 async def setup(client: commands.Bot):
-    await client.add_cog(BotAdmin(client))
+    await client.add_cog(Synch(client))

--- a/cogs/Useless/ping.py
+++ b/cogs/Useless/ping.py
@@ -2,7 +2,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands 
 
-class Useless(commands.Cog):
+class Ping(commands.Cog):
+    
     def __init__(self, client):
         self.client = client
     @app_commands.command(name="ping", description="Replies with Pong!")
@@ -11,4 +12,4 @@ class Useless(commands.Cog):
         
 
 async def setup(client: commands.Bot):
-    await client.add_cog(Useless(client))
+    await client.add_cog(Ping(client))

--- a/main.py
+++ b/main.py
@@ -10,10 +10,15 @@ class MyClient(commands.Bot):
         super().__init__(command_prefix="$", intents=discord.Intents.all())
         
     async def setup_hook(self):
-       for filename in os.listdir("./cogs"):
-            if filename.endswith(".py") and not filename.startswith("__"):
-                await self.load_extension(f"cogs.{filename[:-3]}")
-                print(f"Loaded {filename}")
+        for root, _, files in os.walk("./cogs"):
+            for filename in files:
+                if filename.endswith(".py") and not filename.startswith("__"):
+                    # Convert path to a valid module import format
+                    rel_path = os.path.relpath(root, "./cogs").replace(os.sep, ".")
+                    module_name = f"cogs.{rel_path}.{filename[:-3]}" if rel_path != "." else f"cogs.{filename[:-3]}"
+                    
+                    await self.load_extension(module_name)
+                    print(f"Loaded {module_name}")
          
     async def on_ready(self):
         print('Logged on as', self.user)


### PR DESCRIPTION
Enable easier contributions through highly modular design philosophy. Each command will receive it's own python file decreasing the chances of merge conflicts. 